### PR TITLE
switch auto merge action to pull_request_target

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 name: Auto Merge Dependency Updates
 
 on:
-  - pull_request
+  - pull_request_target
   - pull_request_review
 
 jobs:


### PR DESCRIPTION
See https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/